### PR TITLE
WIP: Refactor proposal session provider

### DIFF
--- a/demos/custom/src/pages/index.tsx
+++ b/demos/custom/src/pages/index.tsx
@@ -11,12 +11,14 @@ import {
 } from "gatsby-theme-shared-ui";
 
 const HomePage = () => {
-  const { isLoggedIn, profile } = useAuth(session => {
-    if (!session.userProfile) {
-      return console.log("Not logged in.");
-    }
-    console.log(`Hello ${session.userProfile.name}!`);
-  });
+  const { isLoggedIn, profile } = useAuth();
+
+  if (!isLoggedIn) {
+    return console.log("Not logged in.");
+  } else {
+    // CompactAuth loses the weird + fancy type assurances that the user union type has
+    console.log(`Hello ${profile && profile.name}!`);
+  }
 
   return (
     <Container textAlign="center">

--- a/demos/minimal/package.json
+++ b/demos/minimal/package.json
@@ -5,6 +5,7 @@
   "description": "Minimal demo for gatsby-theme-auth0",
   "scripts": {
     "dev": "gatsby develop",
+    "debug": "node --inspect-brk ./node_modules/.bin/gatsby develop",
     "build": "gatsby build",
     "clean": "gatsby clean"
   },

--- a/demos/minimal/src/pages/index.js
+++ b/demos/minimal/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { AuthService, useAuth } from "gatsby-theme-auth0";
+import { useAuth } from "gatsby-theme-auth0";
 import {
   Button,
   Container,
@@ -10,7 +10,8 @@ import {
 } from "gatsby-theme-shared-ui";
 
 const HomePage = () => {
-  const { isLoading, isLoggedIn, profile } = useAuth();
+  const session = useAuth();
+  const { isLoading, user, logout, login } = session;
 
   return (
     <Layout>
@@ -19,18 +20,18 @@ const HomePage = () => {
         <h2>Minimal Demo</h2>
         <Title margin="0 0 2.5rem">gatbsy-theme-auth0</Title>
 
-        {profile && (
+        {user.isLoggedIn && (
           <P fontWeight="600" position="relative">
-            Hello {profile.name}
+            Hello {user.userProfile.name}
           </P>
         )}
 
         {isLoading ? (
           <P>Session loading...</P>
-        ) : isLoggedIn ? (
-          <Button onClick={AuthService.logout}>Logout</Button>
+        ) : user.isLoggedIn ? (
+          <Button onClick={logout}>Logout</Button>
         ) : (
-          <Button onClick={AuthService.login}>Login</Button>
+          <Button onClick={login}>Login</Button>
         )}
       </Container>
     </Layout>

--- a/gatsby-theme-auth0/gatsby-browser.js
+++ b/gatsby-theme-auth0/gatsby-browser.js
@@ -1,0 +1,3 @@
+const { wrapRootElement } = require("./src/components/SessionProvider");
+
+exports.wrapRootElement = wrapRootElement;

--- a/gatsby-theme-auth0/gatsby-ssr.js
+++ b/gatsby-theme-auth0/gatsby-ssr.js
@@ -1,0 +1,3 @@
+const { wrapRootElement } = require("./src/components/SessionProvider");
+
+exports.wrapRootElement = wrapRootElement;

--- a/gatsby-theme-auth0/index.d.ts
+++ b/gatsby-theme-auth0/index.d.ts
@@ -1,2 +1,3 @@
 export { default as AuthService } from "./src/auth/service";
 export { default as useAuth } from "./src/hooks/useAuth";
+// TODO: UPDATE ME

--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -1,25 +1,101 @@
 import * as auth0 from "auth0-js";
-import { navigate } from "gatsby";
 import { config } from "./config";
+import { AnonymousUser, User, LoggedInUser, AuthTokens } from "./user";
 
 const isBrowser = typeof window !== "undefined";
 
-export interface SessionState {
-  isLoggedIn: boolean;
-  userProfile?: auth0.Auth0UserProfile;
-  accessToken?: string;
-}
+export type AuthCallback = (state: User) => void;
 
 class Auth {
-  private accessToken?: string;
-  private userProfile?: auth0.Auth0UserProfile;
+  private auth0: auth0.WebAuth | undefined =
+    process.env.AUTH0_DOMAIN && isBrowser
+      ? new auth0.WebAuth(config)
+      : undefined;
 
-  public sessionStateCallback = (_state: SessionState) => {};
+  /**
+   * Handle the auth callback page. Checks the hash from the browser location, parses
+   * the user data and returns that in a promise
+   * @returns {Promise<User>} a Promise with the current user
+   */
+  public handleAuthentication = (): Promise<User> => {
+    return new Promise((resolve, reject) => {
+      this.auth0
+        ? this.auth0.parseHash((err, authResult) => {
+            if (authResult && authResult.accessToken && authResult.idToken) {
+              const user = this.userFromAuthResult(authResult);
+              return resolve(user);
+            } else if (err) {
+              return reject(err);
+            }
+            return resolve();
+          })
+        : resolve(AnonymousUser);
+    });
+  };
 
-  private auth0 = process.env.AUTH0_DOMAIN
-    ? new auth0.WebAuth(config)
-    : undefined;
+  /**
+   * Refresh the user's auth0 session (if their browser claims that they are logged in).
+   * @returns {Promise<User>} a Promise with the current user
+   */
+  public checkSession = (): Promise<User> => {
+    return new Promise((resolve, reject) => {
+      console.log("here", this);
+      this.auth0 && this.isAuthenticated()
+        ? this.auth0.checkSession({}, (err, authResult) => {
+            if (err) reject(err);
+            if (authResult && authResult.accessToken && authResult.idToken) {
+              const user = this.userFromAuthResult(authResult);
+              resolve(user);
+            }
+            if (err && err.error === "login_required") {
+              // User has been logged out from Auth0 server.
+              // Remove local session.
+              this.localLogout();
+              resolve(AnonymousUser);
+            }
+          })
+        : resolve(AnonymousUser);
+    });
+  };
 
+  /**
+   * Turn an incoming auth0 hash from your callback into a user object.
+   * @param authResult The auth result
+   * @returns {User}
+   */
+  private userFromAuthResult(authResult: auth0.Auth0DecodedHash): User {
+    if (!isBrowser) return AnonymousUser;
+    if (
+      !authResult ||
+      !authResult.accessToken ||
+      !authResult.idToken ||
+      !authResult.expiresIn
+    ) {
+      return AnonymousUser;
+    } else {
+      const expiresAt = authResult.expiresIn * 1000 + new Date().getTime();
+      const tokens: AuthTokens = {
+        accessToken: authResult.accessToken,
+        idToken: authResult.idToken,
+        expiresAt,
+      };
+      const user: LoggedInUser = {
+        isLoggedIn: true,
+        profile: authResult.idTokenPayload,
+        tokens: tokens,
+      };
+      localStorage.setItem("isAuthenticated", "true");
+      return user;
+    }
+  }
+
+  /**
+   * Begin the auth0 login flow.
+   *
+   * Sets browser to return to the current page after login (via localStorage).
+   * TODO: consider whether this can be handled via the callback route (eg auth0 returnTo param)
+   *   and whether `window.location.pathname` will work correctly for urls with a hash or query string
+   */
   public login = () => {
     if (!isBrowser) return;
     // Save postLoginUrl so we can redirect user back to where they left off after login screen
@@ -27,73 +103,9 @@ class Auth {
     this.auth0 && this.auth0.authorize();
   };
 
-  public handleAuthentication = () =>
-    new Promise((resolve, reject) => {
-      this.auth0 &&
-        this.auth0.parseHash((err, authResult) => {
-          if (authResult && authResult.accessToken && authResult.idToken) {
-            this.setSession(authResult);
-
-            const postLoginUrl = localStorage.getItem("postLoginUrl");
-            localStorage.removeItem("postLoginUrl");
-            if (postLoginUrl) {
-              navigate(postLoginUrl);
-            }
-            return resolve(authResult);
-          } else if (err) {
-            return reject(err);
-          }
-          return resolve();
-        });
-    });
-
-  public getAccessToken = () => this.accessToken;
-
-  public getUserProfile = () => this.userProfile;
-
-  private setSession(authResult: auth0.Auth0DecodedHash) {
-    if (!isBrowser) return;
-    localStorage.setItem("isLoggedIn", "true");
-    this.accessToken = authResult.accessToken;
-    this.userProfile = authResult.idTokenPayload;
-    this.sessionStateCallback({
-      isLoggedIn: true,
-      userProfile: this.userProfile,
-      accessToken: this.accessToken,
-    });
-  }
-
-  public checkSession = () =>
-    new Promise(resolve => {
-      this.auth0 &&
-        this.auth0.checkSession({}, (err, authResult) => {
-          if (authResult && authResult.accessToken && authResult.idToken) {
-            this.setSession(authResult);
-            return resolve(authResult);
-          }
-          if (err && err.error === "login_required") {
-            // User has been logged out from Auth0 server.
-            // Remove local session.
-            this.localLogout();
-          }
-          return resolve();
-        });
-    });
-
-  public localLogout = () => {
-    if (!isBrowser) return;
-    // Remove tokens and user profile
-    this.accessToken = undefined;
-    this.userProfile = undefined;
-
-    localStorage.removeItem("isLoggedIn");
-    this.sessionStateCallback({
-      isLoggedIn: false,
-      userProfile: undefined,
-      accessToken: undefined,
-    });
-  };
-
+  /**
+   * Log out, both locally and on auth0. Redirects to home.
+   */
   public logout = () => {
     if (!isBrowser) return;
     this.localLogout();
@@ -103,9 +115,20 @@ class Auth {
       });
   };
 
+  /**
+   * Whether the browser _thinks_ that this user is authenticated.
+   */
   public isAuthenticated = () => {
     if (!isBrowser) return false;
-    return localStorage.getItem("isLoggedIn") === "true";
+    return localStorage.getItem("isAuthenticated") === "true";
+  };
+
+  /**
+   * Tell the browser (localStorage) to _stop_ considering this user authenticated.
+   */
+  private localLogout = () => {
+    if (!isBrowser) return;
+    localStorage.removeItem("isAuthenticated");
   };
 }
 

--- a/gatsby-theme-auth0/src/auth/user.ts
+++ b/gatsby-theme-auth0/src/auth/user.ts
@@ -1,39 +1,32 @@
 interface BaseUser {
   isLoggedIn: boolean;
-  userProfile?: auth0.Auth0UserProfile;
+  profile?: auth0.Auth0UserProfile;
   tokens: Tokens;
 }
 
-export interface Tokens {
-  accessToken?: string;
-  idToken?: string;
-  expiresAt?: number;
+export interface AuthTokens {
+  accessToken: string;
+  idToken: string;
+  expiresAt: number;
 }
+
+export type Tokens = {} | AuthTokens;
 
 export type User = LoggedInUser | LoggedOutUser;
 
 export interface LoggedInUser extends BaseUser {
   isLoggedIn: true;
-  userProfile: auth0.Auth0UserProfile;
+  profile: auth0.Auth0UserProfile;
+  tokens: AuthTokens;
 }
 
 export interface LoggedOutUser extends BaseUser {
   isLoggedIn: false;
+  tokens: {};
 }
 
 /** The only LoggedOutUser, the AnonymousUser */
 export const AnonymousUser: LoggedOutUser = {
-  isLoggedIn: false, // todo: necessary?
+  isLoggedIn: false,
   tokens: {},
 };
-
-/**
- * Check whether the user is logged in and narrow their `User` object
- * into a LoggedInUser
- * @export
- * @param {User} u
- * @returns {u is LoggedInUser}
- */
-export function isLoggedInUser(u: User): u is LoggedInUser {
-  return typeof u.tokens.accessToken === "string";
-}

--- a/gatsby-theme-auth0/src/auth/user.ts
+++ b/gatsby-theme-auth0/src/auth/user.ts
@@ -1,0 +1,39 @@
+interface BaseUser {
+  isLoggedIn: boolean;
+  userProfile?: auth0.Auth0UserProfile;
+  tokens: Tokens;
+}
+
+export interface Tokens {
+  accessToken?: string;
+  idToken?: string;
+  expiresAt?: number;
+}
+
+export type User = LoggedInUser | LoggedOutUser;
+
+export interface LoggedInUser extends BaseUser {
+  isLoggedIn: true;
+  userProfile: auth0.Auth0UserProfile;
+}
+
+export interface LoggedOutUser extends BaseUser {
+  isLoggedIn: false;
+}
+
+/** The only LoggedOutUser, the AnonymousUser */
+export const AnonymousUser: LoggedOutUser = {
+  isLoggedIn: false, // todo: necessary?
+  tokens: {},
+};
+
+/**
+ * Check whether the user is logged in and narrow their `User` object
+ * into a LoggedInUser
+ * @export
+ * @param {User} u
+ * @returns {u is LoggedInUser}
+ */
+export function isLoggedInUser(u: User): u is LoggedInUser {
+  return typeof u.tokens.accessToken === "string";
+}

--- a/gatsby-theme-auth0/src/components/SessionProvider.tsx
+++ b/gatsby-theme-auth0/src/components/SessionProvider.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { User, AnonymousUser } from "../auth/user";
+import { navigate, GatsbyBrowser } from "gatsby";
+import auth from "../auth/service";
+
+const isBrowser = typeof window !== "undefined";
+
+interface SessionState {
+  isLoading: boolean;
+  user: User;
+}
+
+export interface Session extends SessionState {
+  setUser: (u: User) => void;
+  logout: () => void;
+  login: () => void;
+}
+
+export const SessionContext = React.createContext<Session>({
+  isLoading: true,
+  user: AnonymousUser,
+  setUser: () => {},
+  logout: () => {},
+  login: () => {},
+});
+
+/**
+ * Wrap our app in the session provider.
+ */
+export const wrapRootElement: GatsbyBrowser["wrapRootElement"] = ({
+  element,
+}) => {
+  return <SessionProvider>{element}</SessionProvider>;
+};
+
+/**
+ * The SessionProvider maintains user authentication state and provides it to the app
+ * via the context API. Auth0-related functions are proxied to the Auth service singleton.
+ */
+export const SessionProvider: React.FC<{}> = ({ children }) => {
+  const [sessionState, setSessionState] = React.useState<SessionState>({
+    isLoading: true,
+    user: AnonymousUser,
+  });
+
+  const setUser = (user: User) => {
+    setSessionState({ isLoading: false, user });
+  };
+
+  const logout = () => {
+    setSessionState({ isLoading: false, user: AnonymousUser });
+    auth.logout();
+    navigate("/");
+  };
+
+  const login = auth.login;
+
+  React.useEffect(() => {
+    if (isBrowser) {
+      auth.checkSession().then(setUser);
+    }
+  }, []);
+
+  return (
+    <SessionContext.Provider
+      value={{ ...sessionState, setUser, logout, login }}
+    >
+      {children}
+    </SessionContext.Provider>
+  );
+};

--- a/gatsby-theme-auth0/src/hooks/useAuth.ts
+++ b/gatsby-theme-auth0/src/hooks/useAuth.ts
@@ -1,41 +1,23 @@
 import * as React from "react";
-import auth, { SessionState } from "../auth/service";
+import { SessionContext } from "../components/SessionProvider";
 
-const useAuth = (stateCallback = (_state: SessionState) => {}) => {
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [isLoggedIn, setIsLoggedIn] = React.useState(auth.isAuthenticated());
-  const [profile, setProfile] = React.useState(auth.getUserProfile());
+interface CompactAuth {
+  isLoading: boolean;
+  isLoggedIn: boolean;
+  profile?: auth0.Auth0UserProfile;
+}
 
-  React.useEffect(() => {
-    // Override `sessionStateCallback` in auth service
-    auth.sessionStateCallback = state => {
-      stateCallback(state);
-      setIsLoggedIn(state.isLoggedIn);
-    };
-
-    (async () => {
-      await auth.checkSession();
-      try {
-        const user = auth.getUserProfile();
-        setProfile(user);
-      } catch (error) {
-        console.log(`Error: ${error}`);
-      }
-
-      setIsLoading(false);
-    })();
-
-    return () => {
-      // Clean up sessionStateCallback
-      auth.sessionStateCallback = () => {};
-    };
-  }, []);
-
-  return {
+/**
+ * React hook for authentication: Fetches the current logged-in state from the Session context provider
+ * Returns the current session loading state, whether the user is logged in, and their profile.
+ */
+const useAuth = (): CompactAuth => {
+  const {
     isLoading,
-    isLoggedIn,
-    profile,
-  };
+    user: { isLoggedIn, profile },
+  } = React.useContext(SessionContext);
+
+  return { isLoading, isLoggedIn, profile };
 };
 
 export default useAuth;

--- a/gatsby-theme-auth0/src/pages/auth/callback.tsx
+++ b/gatsby-theme-auth0/src/pages/auth/callback.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import { WindowLocation } from "@reach/router";
 import AuthService from "../../auth/service";
 import Callback from "../../components/callback";
+import { SessionContext } from "../../components/SessionProvider";
+import { navigate } from "gatsby";
+import { User } from "../../auth/user";
 
 interface Props {
   location: WindowLocation;
@@ -10,9 +13,16 @@ interface Props {
 const CallbackPage: React.FunctionComponent<Props> = props => {
   const { location } = props;
 
+  const session = React.useContext(SessionContext);
+
   React.useEffect(() => {
     if (/access_token|id_token|error/.test(location.hash)) {
-      AuthService.handleAuthentication();
+      AuthService.handleAuthentication().then((user: User) => {
+        session.setUser(user);
+        const postLoginUrl = localStorage.getItem("postLoginUrl");
+        localStorage.removeItem("postLoginUrl");
+        navigate(postLoginUrl || "/");
+      });
     }
   }, []);
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "dev": "yarn workspace demo-minimal dev",
+    "debug": "yarn workspace demo-minimal debug",
     "build": "yarn workspace demo-minimal build",
     "format": "pretty-quick",
     "lint": "eslint --ext .tsx,.ts gatsby-theme-auth0 demos"
@@ -21,6 +22,7 @@
     "eslint-config-prettier": "^6.3.0",
     "eslint-config-react-app": "^4.0.0",
     "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^2.0.1",
     "husky": "^3.0.5",
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,6 +3964,11 @@ eslint-plugin-react-hooks@^1.7.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
+eslint-plugin-react-hooks@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz#e898ec26a0a335af6f7b0ad1f0bedda7143ed756"
+  integrity sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==
+
 eslint-plugin-react@^7.12.4, eslint-plugin-react@^7.14.3:
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"


### PR DESCRIPTION
Eh, I meant to make this a draft PR but I accidentally clicked. This is a 🚧Work in progress 🚧and proposal, wondering your thoughts. I've left a code walkthrough documenting the general approach [here](https://github.com/epilande/gatsby-theme-auth0/pull/31/files#r327551921).

In short this is an adaptation that moves session state management into the react context api, making it available to all components. The Auth class continues to act as a proxy for the auth0 api but no longer maintains session state. This is based on my own [gatsby-theme-auth0](https://github.com/erikdstock/gatsby-theme-auth0-es) but leverages some things you did better.

Please note that I didn't intend to drastically change the api and would be glad to work with you if you think this overall approach is a good idea; This was just me trying to get my previous code to work. I also have a special [route component that handles redirects](https://github.com/erikdstock/gatsby-theme-auth0-es/blob/master/gatsby-theme-auth0/src/components/PrivateRoute.tsx) but did not include that here.
