### PR TITLE
Warn about having both env vars and plugin options

### DIFF
--- a/gatsby-theme-auth0/README.md
+++ b/gatsby-theme-auth0/README.md
@@ -47,6 +47,8 @@ module.exports = {
 };
 ```
 
+Beware that if you set the options above, but also have the environment variables with the names above, the environment variable values will override the options from the code.
+
 Set up your login/logout buttons and you're good to go!
 
 ```jsx


### PR DESCRIPTION
Not sure if it's typical Gatsby plugin behavior, but I spent most of the day debugging this.