### PR TITLE
Add signup method to auth service

### DIFF
--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -28,6 +28,13 @@ class Auth {
     localStorage.setItem("postLoginUrl", window.location.pathname);
     this.auth0 && this.auth0.authorize();
   };
+  
+  public signup = () => {
+    if (!isBrowser) return;
+    // Save postLoginUrl so we can redirect user back to where they left off after signup screen
+    localStorage.setItem("postLoginUrl", window.location.pathname);
+    this.auth0 && this.auth0.authorize({ screen_hint: "signup" });
+  };
 
   public handleAuthentication = () =>
     new Promise((resolve, reject) => {

--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -22,18 +22,11 @@ class Auth {
     ? new auth0.WebAuth(config)
     : undefined;
 
-  public login = () => {
+  public login = (options?: auth0.AuthorizeOptions) => {
     if (!isBrowser) return;
     // Save postLoginUrl so we can redirect user back to where they left off after login screen
     localStorage.setItem("postLoginUrl", window.location.pathname);
-    this.auth0 && this.auth0.authorize();
-  };
-  
-  public signup = () => {
-    if (!isBrowser) return;
-    // Save postLoginUrl so we can redirect user back to where they left off after signup screen
-    localStorage.setItem("postLoginUrl", window.location.pathname);
-    this.auth0 && this.auth0.authorize({ screen_hint: "signup" });
+    this.auth0 && this.auth0.authorize(options);
   };
 
   public handleAuthentication = () =>


### PR DESCRIPTION
- New signup method brings up auth page defaulted to signup rather than login scenario.
- Uses `screen_hint` option of `auth0.authorize` method (see [universal login docs](https://auth0.com/docs/universal-login/new?_ga=2.102997824.1917859132.1589605344-57314141.1581297212#signup)).