### PR TITLE
reject if checkSession returned error

### DIFF
--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -70,7 +70,7 @@ class Auth {
   }
 
   public checkSession = () =>
-    new Promise(resolve => {
+    new Promise((resolve, reject) => {
       this.auth0 &&
         this.auth0.checkSession({}, (err, authResult) => {
           if (authResult && authResult.accessToken && authResult.idToken) {
@@ -81,6 +81,7 @@ class Auth {
             // User has been logged out from Auth0 server.
             // Remove local session.
             this.localLogout();
+            return reject();
           }
           return resolve();
         });

--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -81,7 +81,7 @@ class Auth {
             // User has been logged out from Auth0 server.
             // Remove local session.
             this.localLogout();
-            return reject();
+            return reject(err);
           }
           return resolve();
         });


### PR DESCRIPTION
This PR makes `checkSession` explicitly `reject` after removing the local session, if auth0.checkSession returned an error. Previously, the developer had to check localStorage for `isLoggedIn`, because `checkSession` would always resolve.