### PR TITLE
Allows for logout options

### DIFF
--- a/demos/custom/src/pages/index.tsx
+++ b/demos/custom/src/pages/index.tsx
@@ -36,7 +36,7 @@ const HomePage = () => {
       )}
 
       {isLoggedIn ? (
-        <Button onClick={AuthService.logout}>Logout</Button>
+        <Button onClick={() => AuthService.logout()}>Logout</Button>
       ) : (
         <Button onClick={AuthService.login}>Login</Button>
       )}

--- a/demos/minimal/src/pages/index.js
+++ b/demos/minimal/src/pages/index.js
@@ -28,7 +28,7 @@ const HomePage = () => {
         {isLoading ? (
           <P>Session loading...</P>
         ) : isLoggedIn ? (
-          <Button onClick={AuthService.logout}>Logout</Button>
+          <Button onClick={() => AuthService.logout()}>Logout</Button>
         ) : (
           <Button onClick={AuthService.login}>Login</Button>
         )}

--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -11,6 +11,11 @@ export interface SessionState {
   idToken?: string;
 }
 
+export interface LogoutOptions {
+  returnTo?: string;
+  client_id?: string;
+}
+
 class Auth {
   private accessToken?: string;
   private idToken?: string;
@@ -102,13 +107,15 @@ class Auth {
     });
   };
 
-  public logout = () => {
+  public logout = (opts?: LogoutOptions) => {
     if (!isBrowser) return;
     this.localLogout();
     this.auth0 &&
-      this.auth0.logout({
-        returnTo: window.location.origin,
-      });
+      this.auth0.logout(
+        opts || {
+          returnTo: window.location.origin,
+        },
+      );
   };
 
   public isAuthenticated = () => {

--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -11,11 +11,6 @@ export interface SessionState {
   idToken?: string;
 }
 
-export interface LogoutOptions {
-  returnTo?: string;
-  client_id?: string;
-}
-
 class Auth {
   private accessToken?: string;
   private idToken?: string;
@@ -107,7 +102,7 @@ class Auth {
     });
   };
 
-  public logout = (opts?: LogoutOptions) => {
+  public logout = (opts?: auth0.LogoutOptions) => {
     if (!isBrowser) return;
     this.localLogout();
     this.auth0 &&


### PR DESCRIPTION
Currently logging out always takes you to `window.location.origin`, and this is hardcoded on the auth service so there's no way of customising it. 

This PR allows you to supply configuration to the logout action so redirects to custom routes are supported.