### PR TITLE
Expose changePassword method

### DIFF
--- a/gatsby-theme-auth0/src/auth/service.ts
+++ b/gatsby-theme-auth0/src/auth/service.ts
@@ -86,6 +86,11 @@ class Auth {
         });
     });
 
+  public changePassword = (options: auth0.ChangePasswordOptions, callback: auth0.Auth0Callback<any>) => {
+      if (!isBrowser) return;
+      this.auth0 && this.auth0.changePassword(options, callback);
+  };
+
   public localLogout = () => {
     if (!isBrowser) return;
     // Remove tokens and user profile


### PR DESCRIPTION
Allows client to support scenario where use is logged in and wants to change their password. From Auth0's perspective, this is the same as a password reset, but from the user's perspective, it's not.