### PR TITLE
Only call checkSession if the token has expired

### DIFF
--- a/gatsby-theme-auth0/src/hooks/useAuth.ts
+++ b/gatsby-theme-auth0/src/hooks/useAuth.ts
@@ -17,7 +17,6 @@ const useAuth = (stateCallback = (_state: SessionState) => {}) => {
       let profile = auth.getUserProfile();
       // If it's past the expiration date of the token, checkSession()
       if (!profile || Date.now() > profile.exp * 1000) {
-        console.debug(`useAuth.useEffect calling checkSession()`);
         await auth.checkSession();
         profile = auth.getUserProfile();
       }

--- a/gatsby-theme-auth0/src/hooks/useAuth.ts
+++ b/gatsby-theme-auth0/src/hooks/useAuth.ts
@@ -14,14 +14,14 @@ const useAuth = (stateCallback = (_state: SessionState) => {}) => {
     };
 
     (async () => {
-      await auth.checkSession();
-      try {
-        const user = auth.getUserProfile();
-        setProfile(user);
-      } catch (error) {
-        console.log(`Error: ${error}`);
+      let profile = auth.getUserProfile();
+      // If it's past the expiration date of the token, checkSession()
+      if (!profile || Date.now() > profile.exp * 1000) {
+        console.debug(`useAuth.useEffect calling checkSession()`);
+        await auth.checkSession();
+        profile = auth.getUserProfile();
       }
-
+      setProfile(profile);
       setIsLoading(false);
     })();
 


### PR DESCRIPTION
This small change addresses #150 by not calling checkSession() unnecessarily.

## Before

`checkSession()` called from every `useAuth()`. Led to #150. In a typical Gatsby app, this led to many requests to Auth0 from every page:

![image](https://user-images.githubusercontent.com/33569/86067608-1dd34800-ba2a-11ea-8913-94c5f1fbc596.png)

## After

`checkSession()` only called after the token has expired. Same app with the same navigation pattern (3 clicks/pages):

![image](https://user-images.githubusercontent.com/33569/86067309-6f2f0780-ba29-11ea-8658-8915ce140724.png)

## Potential drawbacks

1. In the rare event that the user changes their information with Auth0 (or the social identity profile) while logged into the app, that information won't be reflected until they refresh the token. Users typically tend to reload the page in this scenario, which would typically trigger the app calling `checkSession()` in its initialization, so the issue is minor.
2. If the user's token is revoked, they'll still be able to access client-side information they had access to, until the token expires (2 hours by default with Auth0, I think). However, server-side security would reject the invalidated JWT.

## Notes

I've remove the try/catch from that block, as I'm not sure when it the `catch` would ever occur. setUser() wouldn't trigger is, and `auth.getUserProfile();` simply accesses `this.userProfile;`.